### PR TITLE
Remove jsonlite from the DESCRIPTION to finish running R-CMD-Check workflow

### DIFF
--- a/.github/workflows/R-CMD-check-and-Release.yml
+++ b/.github/workflows/R-CMD-check-and-Release.yml
@@ -21,9 +21,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: 'release'}
-          - {os: macOS-latest, r: 'release'}
-          - {os: ubuntu-latest, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: windows-latest, r: '4.0.2'}
+          - {os: macOS-latest, r: '4.0.2'}
+          - {os: ubuntu-latest, r: '4.0.2', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}

--- a/.github/workflows/R-CMD-check-and-Release.yml
+++ b/.github/workflows/R-CMD-check-and-Release.yml
@@ -1,13 +1,13 @@
-on: [workflow_dispatch]
-# on: 
-#   push:
-#     branches:
-#       - master
-#     tags:
-#       - v*
-#   pull_request:
-#     branches:
-#       - master
+# on: [workflow_dispatch]
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - v*
+  pull_request:
+    branches:
+      - master
 
 name: R-CMD-check and release
 

--- a/.github/workflows/R-CMD-check-and-Release.yml
+++ b/.github/workflows/R-CMD-check-and-Release.yml
@@ -21,9 +21,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: '4.0.2'}
-          - {os: macOS-latest, r: '4.0.2'}
-          - {os: ubuntu-latest, r: '4.0.2', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: windows-latest, r: 'release'}
+          - {os: macOS-latest, r: 'release'}
+          - {os: ubuntu-latest, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,10 +11,7 @@ LazyData: true
 Depends: R (>= 4.0.0)
 StagedInstall: no
 Imports:
-    jsonlite,
     Rcpp
-Remotes:
-    jeroen/jsonlite
 RoxygenNote: 7.1.1
 LinkingTo: 
     Rcpp

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ Imports:
     jsonlite,
     Rcpp
 Remotes:
-    cstawitz/jsonlite
+    jeroen/jsonlite
 RoxygenNote: 7.1.1
 LinkingTo: 
     Rcpp


### PR DESCRIPTION
I removed jsonlite from the DESCRIPTION to solve the issue https://github.com/nmfs-fish-tools/r4MAS/issues/65
The new error is related to r4MAS memory mapping: 
```
*** caught segfault *** 
address 0x0, cause 'memory not mapped'
```
